### PR TITLE
Fix boolean if check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
     - name: Download generated messaging helm values ⬇️
-      if: ${{ inputs.has-messaging == true }}
+      if: ${{ inputs.has-messaging == 'true' }}
       uses: actions/download-artifact@v2
       with:
         name: message-artifact-values


### PR DESCRIPTION
In GithubAction context, the boolean input fields are not treated as boolean, therefore a string comparison is needed.