### PR TITLE
EPNG-11279: Update outdated github actions

### DIFF
--- a/.github/workflows/package-docker-image.yaml
+++ b/.github/workflows/package-docker-image.yaml
@@ -6,13 +6,13 @@ on:
     paths:
       - 'package-action/**'
       - '.github/workflows/package-docker-image.yaml'
-  
+
 jobs:
   build-docker-image:
     name: Build and push docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.BYD_DOCKERHUB_USER }}

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Download generated messaging helm values ⬇️
       if: ${{ inputs.has-messaging == 'true' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: message-artifact-values
         path: build/message-artifacts-helm


### PR DESCRIPTION
This updates the two outdated github actions. The `download-artifact` action is scheduled to be deprecated in the near future (Nov 30, 2024).

We had some issues related to `ng-shop` after we updated our `upload-artifact` to the next version. It would no longer be able to properly update/publish the helm charts. As mentioned in EPNG-11279, I assume this is because we were then using a different version of `upload-artifact` compared to this actions `download-artifact`, leading it to failing to find the required artifacts: See https://github.com/ePages-de/ng-shop/actions/runs/9346553989/job/25722134619

Updating these and creating a new tag called `v5` based on master should allow us to run with the newer version of `upload-artifact`. 