### PR TITLE
EPNG-12983: Add dependabot and pin versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: direct
+    reviewers:
+      - "ePages-de/team-x"
+      - "ePages-de/team-white"
+    cooldown:
+      default-days: 5

--- a/.github/workflows/package-docker-image.yaml
+++ b/.github/workflows/package-docker-image.yaml
@@ -12,8 +12,8 @@ jobs:
     name: Build and push docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.BYD_DOCKERHUB_USER }}
           password: ${{ secrets.BYD_DOCKERHUB_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
     - uses: actions/checkout@v4
     - name: Download generated messaging helm values ⬇️
       if: ${{ inputs.has-messaging == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: message-artifact-values
         path: build/message-artifacts-helm


### PR DESCRIPTION
This change pins all of the versions of the github actions to the commit hashes of hte latest version of their current ones. For example, `actions/checkout@v4` was pinned to `v4.3.1` since that is the latest version of v4. In addition, dependabot config is added to smooth out the upgrading in the future.